### PR TITLE
Performance improvement: Create set in constructor

### DIFF
--- a/lib/jisx0208/processor.rb
+++ b/lib/jisx0208/processor.rb
@@ -18,6 +18,9 @@ module JISX0208
       @first_level_ranges = collect_unicode_set(mappings, 0x3021, 0x4F53)
       @second_level_ranges = collect_unicode_set(mappings, 0x5021, 0x7426)
       @others_ranges = collect_unicode_set(mappings, 0x2120, 0x2840)
+      @common = @others_ranges + @first_level_ranges
+      @jisx0208_kanji = @first_level_ranges + @second_level_ranges
+      @jisx0208 = @first_level_ranges + @second_level_ranges + @others_ranges
     end
 
     def contains_first_level_kanji?(string)
@@ -47,19 +50,16 @@ module JISX0208
     end
 
     def only_jisx0208_kanji?(string)
-      jisx0208 = @first_level_ranges + @second_level_ranges
-      string.each_char.all? { |char| jisx0208.include?(char.ord) }
+      string.each_char.all? { |char| @jisx0208_kanji.include?(char.ord) }
     end
 
     def only_jisx0208?(string)
-      jisx0208 = @first_level_ranges + @second_level_ranges + @others_ranges
-      string.each_char.all? { |char| jisx0208.include?(char.ord) }
+      string.each_char.all? { |char| @jisx0208.include?(char.ord) }
     end
 
     # hiragana, katakana, multi byte symbols, first level kanji
     def only_common_japanese_characters?(string)
-      common = @others_ranges + @first_level_ranges
-      string.each_char.all? { |char| common.include?(char.ord) }
+      string.each_char.all? { |char| @common.include?(char.ord) }
     end
 
     private


### PR DESCRIPTION
close #8
Performance improvement: Create set in constructor. I checked performance with the following script :
```ruby
# frozen_string_literal: true

require "csv"
require "benchmark"
require_relative "lib/jisx0208"

file_path = "performance/ja_zh.csv"
jisx0208 = JISX0208::Code.new

words = []
CSV.foreach(file_path, headers: false) do |row|
  words << row[0]
end

puts "jisx0208.only_jisx0208_kanji?(word)"
Benchmark.bm do |x|
  x.report("Processing CSV:") do
    words.each do |word|
      jisx0208.only_jisx0208_kanji?(word)
    end
  end
end

puts "jisx0208.only_common_japanese_characters?(word)"
Benchmark.bm do |x|
  x.report("Processing CSV:") do
    words.each do |word|
      jisx0208.only_common_japanese_characters?(word)
    end
  end
end
```

## before

```
jisx0208.only_jisx0208_kanji?(word)
                     user     system      total        real
Processing CSV:  1.609064   0.171078   1.780142 (  1.780292)
jisx0208.only_common_japanese_characters?(word)
                     user     system      total        real
Processing CSV:  1.389286   0.107887   1.497173 (  1.497272)
```

## after

```
jisx0208.only_jisx0208_kanji?(word)
                     user     system      total        real
Processing CSV:  0.014246   0.000429   0.014675 (  0.014679)
jisx0208.only_common_japanese_characters?(word)
                     user     system      total        real
Processing CSV:  0.015026   0.000404   0.015430 (  0.015431)
```